### PR TITLE
build: Use standard upgrade-python-requirements file

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -1,55 +1,27 @@
-name: Upgrade Requirements
+name: Upgrade Python Requirements
 
 on:
   schedule:
-    # will start the job at 02:30 UTC every Tuesday
     - cron: "30 2 * * 2"
   workflow_dispatch:
     inputs:
       branch:
-        description: "Target branch to create requirements PR against"
+        description: "Target branch against which to create requirements PR"
         required: true
         default: 'master'
 
 jobs:
-  upgrade_requirements:
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        python-version: ["3.8"]
-
-    steps:
-      - name: setup target branch
-        run: echo "target_branch=$(if ['${{ github.event.inputs.branch }}' = '']; then echo 'master'; else echo '${{ github.event.inputs.branch }}'; fi)" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v1
-        with:
-          ref: ${{ env.target_branch }}
-      
-      - name: setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: make upgrade
-        run: |
-          cd $GITHUB_WORKSPACE
-          make upgrade
-
-      - name: setup testeng-ci
-        run: |
-          git clone https://github.com/openedx/testeng-ci.git
-          cd $GITHUB_WORKSPACE/testeng-ci
-          pip install -r requirements/base.txt
-      - name: create pull request
-        env:
-          GITHUB_TOKEN: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
-          GITHUB_USER_EMAIL: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
-        run: |  
-          cd $GITHUB_WORKSPACE/testeng-ci
-          python -m jenkins.pull_request_creator --repo-root=$GITHUB_WORKSPACE \
-          --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
-          --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
-          --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
-          --user-reviewers="" --team-reviewers="" --delete-old-pull-requests
+  call-upgrade-python-requirements-workflow:
+    uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
+    with:
+      branch: ${{ github.event.inputs.branch || 'master' }}
+      # optional parameters below; fill in if you'd like github or email notifications
+      # user_reviewers: ""
+      # team_reviewers: ""
+      # email_address: ""
+      # send_success_notification: false
+    secrets:
+      requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
+      requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
+      edx_smtp_username: ${{ secrets.EDX_SMTP_USERNAME }}
+      edx_smtp_password: ${{ secrets.EDX_SMTP_PASSWORD }}


### PR DESCRIPTION
The upgrade-python-requirements file in this repo is outdated; it should use the standard template defined in the .github repo, under workflow-templates directory.

Note I have tried to replace the `'$default-branch'` variable with the (unquoted) name of this repo's master branch; if that did not happen correctly, do not merge this branch until it is fixed.