### PR TITLE
fix: reorder, remove unused, update Fragment import

### DIFF
--- a/acid/acid.py
+++ b/acid/acid.py
@@ -1,16 +1,15 @@
 """An XBlock checking container/block relationships for correctness."""
 
 import logging
-import pkg_resources
 import random
+
+import pkg_resources
 import webob
 from lazy import lazy
 from mako.lookup import TemplateLookup
-
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock, XBlockAside
-from xblock.fields import Scope, Dict
-from xblock.fragment import Fragment
-import six
+from xblock.fields import Dict, Scope
 
 
 def generate_fields(cls):


### PR DESCRIPTION
Seeing deprecation warnings in downstream tests.  This block doesn't seem to have any tests of it's own.

```
/home/e0d/.virtualenvs/xblock-sdk/lib/python3.8/site-packages/acid/acid.py:218: DeprecationWarning: xblock.fragment is deprecated. Please use web_fragments.fragment instead
    frag = Fragment(self.render_template(
```