### PR TITLE
docs: Fix python classifier for license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Previously it was incorrectly set as Apache.