### PR TITLE
Fix pypi-publish git workflow issue

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install pip
         run: pip install -r requirements/pip.txt
 
+      - name: Install Dependencies
+        run: pip install setuptools wheel
+
       - name: Build package
         run: python setup.py sdist bdist_wheel
 


### PR DESCRIPTION
Fix pypi-publish git workflow issue

Error: https://github.com/openedx/acid-block/actions/runs/8344151124/job/22835936244#step:7:50