### PR TITLE
feat: Add python311 support

### DIFF
--- a/acid/__init__.py
+++ b/acid/__init__.py
@@ -1,3 +1,3 @@
 from .acid import AcidBlock, AcidParentBlock, AcidAside
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ fs==2.4.16
     # via xblock
 lazy==1.6
     # via -r requirements/base.in
-lxml==5.1.0
+lxml==5.2.1
     # via xblock
 mako==1.3.2
     # via
@@ -32,11 +32,11 @@ six==1.16.0
     # via
     #   fs
     #   python-dateutil
-web-fragments==2.1.0
+web-fragments==2.2.0
     # via xblock
 webob==1.8.7
     # via xblock
-xblock==2.0.0
+xblock==3.1.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -21,3 +21,12 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
+
+# opentelemetry requires version 6.x at the moment:
+# https://github.com/open-telemetry/opentelemetry-python/issues/3570
+# Normally this could be added as a constraint in edx-django-utils, where we're
+# adding the opentelemetry dependency. However, when we compile pip-tools.txt,
+# that uses version 7.x, and then there's no undoing that when compiling base.txt.
+# So we need to pin it globally, for now.
+# Ticket for unpinning: https://github.com/openedx/edx-lint/issues/407
+importlib-metadata<7

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.43.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.1.1
+setuptools==69.2.0
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,12 +4,14 @@
 #
 #    make upgrade
 #
-build==1.1.1
+build==1.2.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==7.0.2
-    # via build
+importlib-metadata==6.11.0
+    # via
+    #   -c requirements/common_constraints.txt
+    #   build
 packaging==24.0
     # via build
 pip-tools==7.4.1
@@ -25,7 +27,7 @@ tomli==2.0.1
     #   pyproject-hooks
 wheel==0.43.0
     # via pip-tools
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,9 +15,9 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.6.0
+code-annotations==1.7.0
     # via edx-lint
-coverage[toml]==7.4.3
+coverage[toml]==7.4.4
     # via pytest-cov
 dill==0.3.8
     # via pylint
@@ -59,7 +59,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pytest==8.1.1
     # via pytest-cov
-pytest-cov==4.1.0
+pytest-cov==5.0.0
     # via -r requirements/test.in
 python-slugify==8.0.4
     # via code-annotations

--- a/setup.py
+++ b/setup.py
@@ -131,5 +131,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.11',
     ]
 )


### PR DESCRIPTION
## Description 

This PR contains changes for upgrading python 3.8 to python 3.11.

Changes include :-
- Dependencies and version upgrades



Done as a part of following :-
- https://github.com/openedx/public-engineering/issues/233
- https://github.com/openedx/edx-platform/issues/34229
- https://github.com/openedx/acid-block/issues/154
