### PR TITLE
fix: Update pypi-publish.yml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,19 +7,14 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: [3.11, 3.12]
-    
+    runs-on: ubuntu-latest    
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Install pip
         run: pip install -r requirements/pip.txt


### PR DESCRIPTION
We should only be publishing once and not using a matrix strategy for publishing the package.  When we try to publish multiple times we create a race condition that causes one of the publishes to fail.